### PR TITLE
allow to specify base branch when creating branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ When `:Promiscuous` is called with no arguments, an `:FZF` fuzzy finder window i
 
 If you're using [tmux](https://tmux.github.io/) then your status line will automatically refresh when `:Promiscuous` checks out a branch. This is very convenient when you display [git information in your status line](https://github.com/shuber/tmux-git).
 
+By default, if calling `:Promiscuous new-branch-name` with a not
+existing branch, Promiscuous will create that branch as if you executed
+`git checkout new-branch-name`. An option allows you to execute instead
+`git checkout -b new-branch-name origin/master` and even
+`git fetch; git checkout -b new-branch-name origin/master`.
+
 Similar projects:
 
 * http://www.eclipse.org/mylyn/
@@ -72,6 +78,11 @@ let g:promiscuous_save = 'promiscuous#session#save'
 
 " Log all executed commands with echom
 let g:promiscuous_verbose = 0
+
+" The callback used to determine which base to create a new branch on
+let g:promiscuous_base_branch = 'promiscuous#git#basebranchcurrentbranch'
+" let g:promiscuous_base_branch = 'promiscuous#git#basebranchoriginmaster'
+" let g:promiscuous_base_branch = 'promiscuous#git#basebranchlatestoriginmaster'
 ```
 
 ```vim
@@ -123,6 +134,7 @@ The output below occurred when switching from `master` to `something-new` then b
 [Promiscuous] source /Users/Sean/.vim/promiscuous/Code_vim_promiscuous_master.vim
 [Promiscuous] Checkout master
 ```
+
 
 
 ## Contributing

--- a/autoload/promiscuous/git.vim
+++ b/autoload/promiscuous/git.vim
@@ -2,11 +2,24 @@ function! promiscuous#git#branch()
   return systemlist('git symbolic-ref --short HEAD')[0]
 endfunction
 
+function! promiscuous#git#basebranchcurrentbranch(new_branch)
+  return ''
+endfunction
+
+function! promiscuous#git#basebranchoriginmaster(new_branch)
+  return 'origin/master'
+endfunction
+
+function! promiscuous#git#basebranchlatestoriginmaster(new_branch)
+  call promiscuous#helpers#exec('!git fetch origin')
+  return 'origin/master'
+endfunction
+
 function! promiscuous#git#checkout(unsanitized_branch)
   let l:branch = substitute(a:unsanitized_branch, '^\s*\(.\{-}\)\s*$', '\1', '')
   let l:checkout = 'git checkout '
   let l:checkout_old = l:checkout . l:branch
-  let l:checkout_new = l:checkout . '-b ' . l:branch
+  let l:checkout_new = l:checkout . '-b ' . l:branch . ' ' . call(g:promiscuous_base_branch, [l:branch], {})
   let l:checkout_command = '!' . l:checkout_old . ' || ' . l:checkout_new
   call promiscuous#helpers#exec(l:checkout_command)
 endfunction

--- a/plugin/promiscuous.vim
+++ b/plugin/promiscuous.vim
@@ -27,6 +27,13 @@ if !exists('g:promiscuous_verbose')
   let g:promiscuous_verbose = 0
 endif
 
+if !exists('g:promiscuous_base_branch')
+  " The callback used to determine which base to create a new branch on
+  let g:promiscuous_base_branch = 'promiscuous#git#basebranchcurrentbranch'
+  " let g:promiscuous_base_branch = 'promiscuous#git#basebranchoriginmaster'
+  " let g:promiscuous_base_branch = 'promiscuous#git#basebranchlatestoriginmaster'
+endif
+
 command! -nargs=? Promiscuous :call Promiscuous(<f-args>)
 
 function! Promiscuous(...)


### PR DESCRIPTION
One can override the default `promiscuous#git#basebranch(new_branch)`
function to return the base branch on which new branches should be
created.

This commit is backward compatible as by default it keeps the previous
behavior, that is creating a new branch based on the current commit.